### PR TITLE
0.4.6

### DIFF
--- a/TooManyItems/Items/Lunar/CarvingBlade.cs
+++ b/TooManyItems/Items/Lunar/CarvingBlade.cs
@@ -36,11 +36,11 @@ namespace TooManyItems
                 "ITEM_CARVINGBLADE_DESC"
             }
         );
-        // This damage is capped at 20000% of the player's base damage.
+        // This damage is capped at 10000% of the player's base damage.
         public static ConfigurableValue<float> damageCapMultiplier = new(
             "Item: Carving Blade",
             "Damage Cap",
-            200f,
+            100f,
             "Maximum damage on-hit. This value is multiplied by the user's base damage.\nSet this value to -1 to remove the cap.",
             new List<string>()
             {

--- a/TooManyItems/Items/Tier1/Photodiode.cs
+++ b/TooManyItems/Items/Tier1/Photodiode.cs
@@ -25,7 +25,7 @@ namespace TooManyItems
         public static ConfigurableValue<float> attackSpeedOnHit = new(
             "Item: Photodiode",
             "Attack Speed",
-            2.5f,
+            2f,
             "Percent attack speed gained on-hit.",
             new List<string>()
             {
@@ -45,7 +45,7 @@ namespace TooManyItems
         public static ConfigurableValue<int> maxAttackSpeedStacks = new(
             "Item: Photodiode",
             "Max Stacks",
-            8,
+            10,
             "Max attack speed stacks allowed per stack of item.",
             new List<string>()
             {

--- a/TooManyItems/Items/Tier2/Hoodie.cs
+++ b/TooManyItems/Items/Tier2/Hoodie.cs
@@ -36,7 +36,7 @@ namespace TooManyItems
         public static ConfigurableValue<float> rechargeTime = new(
             "Item: Fleece Hoodie",
             "Recharge Time",
-            8f,
+            10f,
             "Time this item takes to recharge.",
             new List<string>()
             {

--- a/TooManyItems/Items/Tier3/GlassMarbles.cs
+++ b/TooManyItems/Items/Tier3/GlassMarbles.cs
@@ -23,7 +23,7 @@ namespace TooManyItems
         public static ConfigurableValue<float> damagePerLevelPerStack = new(
             "Item: Glass Marbles",
             "Damage Increase",
-            2.5f,
+            2f,
             "Amount of base damage gained per level per stack.",
             new List<string>()
             {

--- a/TooManyItems/Items/Tier3/HorseshoeStatistics.cs
+++ b/TooManyItems/Items/Tier3/HorseshoeStatistics.cs
@@ -17,7 +17,6 @@ namespace TooManyItems
         private float _regenerationBonus;
         private float _shieldBonus;
         private float _moveSpeedPercentBonus;
-        private float _luckBonus;
 
         public float MaxHealthBonus
         {
@@ -37,8 +36,7 @@ namespace TooManyItems
                         _armorBonus,
                         _regenerationBonus,
                         _shieldBonus,
-                        _moveSpeedPercentBonus,
-                        _luckBonus
+                        _moveSpeedPercentBonus
                     ).Send(NetworkDestination.Clients);
                 }
             }
@@ -61,8 +59,7 @@ namespace TooManyItems
                         _armorBonus,
                         _regenerationBonus,
                         _shieldBonus,
-                        _moveSpeedPercentBonus,
-                        _luckBonus
+                        _moveSpeedPercentBonus
                     ).Send(NetworkDestination.Clients);
                 }
             }
@@ -85,8 +82,7 @@ namespace TooManyItems
                         _armorBonus,
                         _regenerationBonus,
                         _shieldBonus,
-                        _moveSpeedPercentBonus,
-                        _luckBonus
+                        _moveSpeedPercentBonus
                     ).Send(NetworkDestination.Clients);
                 }
             }
@@ -109,8 +105,7 @@ namespace TooManyItems
                         _armorBonus,
                         _regenerationBonus,
                         _shieldBonus,
-                        _moveSpeedPercentBonus,
-                        _luckBonus
+                        _moveSpeedPercentBonus
                     ).Send(NetworkDestination.Clients);
                 }
             }
@@ -133,8 +128,7 @@ namespace TooManyItems
                         _armorBonus,
                         _regenerationBonus,
                         _shieldBonus,
-                        _moveSpeedPercentBonus,
-                        _luckBonus
+                        _moveSpeedPercentBonus
                     ).Send(NetworkDestination.Clients);
                 }
             }
@@ -157,8 +151,7 @@ namespace TooManyItems
                         value,
                         _regenerationBonus,
                         _shieldBonus,
-                        _moveSpeedPercentBonus,
-                        _luckBonus
+                        _moveSpeedPercentBonus
                     ).Send(NetworkDestination.Clients);
                 }
             }
@@ -181,8 +174,7 @@ namespace TooManyItems
                         _armorBonus,
                         value,
                         _shieldBonus,
-                        _moveSpeedPercentBonus,
-                        _luckBonus
+                        _moveSpeedPercentBonus
                     ).Send(NetworkDestination.Clients);
                 }
             }
@@ -205,8 +197,7 @@ namespace TooManyItems
                         _armorBonus,
                         _regenerationBonus,
                         value,
-                        _moveSpeedPercentBonus,
-                        _luckBonus
+                        _moveSpeedPercentBonus
                     ).Send(NetworkDestination.Clients);
                 }
             }
@@ -229,31 +220,6 @@ namespace TooManyItems
                         _armorBonus,
                         _regenerationBonus,
                         _shieldBonus,
-                        value,
-                        _luckBonus
-                    ).Send(NetworkDestination.Clients);
-                }
-            }
-        }
-        public float LuckBonus
-        {
-            get { return _luckBonus; }
-            set
-            {
-                _luckBonus = value;
-                if (NetworkServer.active)
-                {
-                    new Sync(
-                        gameObject.GetComponent<NetworkIdentity>().netId,
-                        _maxHealthBonus,
-                        _baseDamageBonus,
-                        _attackSpeedPercentBonus,
-                        _critChanceBonus,
-                        _critDamageBonus,
-                        _armorBonus,
-                        _regenerationBonus,
-                        _shieldBonus,
-                        _moveSpeedPercentBonus,
                         value
                     ).Send(NetworkDestination.Clients);
                 }
@@ -272,7 +238,6 @@ namespace TooManyItems
             float regenerationBonus;
             float shieldBonus;
             float moveSpeedPercentBonus;
-            float luckBonus;
 
             public Sync()
             {
@@ -280,7 +245,7 @@ namespace TooManyItems
 
             public Sync(NetworkInstanceId objId,
                 float maxHealth, float baseDamage, float attackSpeed, float critChance, float critDamage,
-                float armor, float regen, float shield, float moveSpeed, float luck)
+                float armor, float regen, float shield, float moveSpeed)
             {
                 this.objId = objId;
                 maxHealthBonus = maxHealth;
@@ -292,7 +257,6 @@ namespace TooManyItems
                 regenerationBonus = regen;
                 shieldBonus = shield;
                 moveSpeedPercentBonus = moveSpeed;
-                luckBonus = luck;
             }
 
             public void Deserialize(NetworkReader reader)
@@ -307,7 +271,6 @@ namespace TooManyItems
                 regenerationBonus = reader.ReadSingle();
                 shieldBonus = reader.ReadSingle();
                 moveSpeedPercentBonus = reader.ReadSingle();
-                luckBonus = reader.ReadSingle();
             }
 
             public void OnReceived()
@@ -329,7 +292,6 @@ namespace TooManyItems
                         component.RegenerationBonus = regenerationBonus;
                         component.ShieldBonus = shieldBonus;
                         component.MoveSpeedPercentBonus = moveSpeedPercentBonus;
-                        component.LuckBonus = luckBonus;
                     }
                 }
             }
@@ -346,7 +308,6 @@ namespace TooManyItems
                 writer.Write(regenerationBonus);
                 writer.Write(shieldBonus);
                 writer.Write(moveSpeedPercentBonus);
-                writer.Write(luckBonus);
             }
         }
     }

--- a/TooManyItems/Items/Void/IronHeartVoid.cs
+++ b/TooManyItems/Items/Void/IronHeartVoid.cs
@@ -36,7 +36,7 @@ namespace TooManyItems
         public static ConfigurableValue<float> percentDamagePerStack = new(
             "Item: Defiled Heart",
             "Bonus Damage Scaling",
-            1f,
+            1.5f,
             "Percent of maximum health gained as base damage.",
             new List<string>()
             {

--- a/TooManyItems/Items/Void/ShadowCrest.cs
+++ b/TooManyItems/Items/Void/ShadowCrest.cs
@@ -23,7 +23,7 @@ namespace TooManyItems
         public static ConfigurableValue<float> regenPerSecond = new(
             "Item: Shadow Crest",
             "Regen Per Second",
-            1.5f,
+            1.2f,
             "Percentage of missing health regenerated per second.",
             new List<string>()
             {

--- a/TooManyItems/TooManyItems.cs
+++ b/TooManyItems/TooManyItems.cs
@@ -137,34 +137,48 @@ namespace TooManyItems
         {
             On.RoR2.Items.ContagiousItemManager.Init += (orig) =>
             {
-                List<ItemDef.Pair> newVoidPairs = new List<ItemDef.Pair>
+                List<ItemDef.Pair> newVoidPairs = new List<ItemDef.Pair>{ };
+
+                if (RedBlueGlasses.isEnabled)
                 {
                     // 3D Glasses => Instakill Glasses
-                    new ItemDef.Pair()
+                    newVoidPairs.Add(new ItemDef.Pair()
                     {
                         itemDef1 = RedBlueGlasses.itemDef,
                         itemDef2 = DLC1Content.Items.CritGlassesVoid
-                    },
+                    });
+                }
+
+                if (Thumbtack.isEnabled)
+                {
                     // Thumbtack => Needletick
-                    new ItemDef.Pair()
+                    newVoidPairs.Add(new ItemDef.Pair()
                     {
                         itemDef1 = Thumbtack.itemDef,
                         itemDef2 = DLC1Content.Items.BleedOnHitVoid
-                    },
+                    });
+                }
+
+                if (IronHeart.isEnabled && IronHeartVoid.isEnabled)
+                {
                     // Iron Heart => Defiled Heart
-                    new ItemDef.Pair()
+                    newVoidPairs.Add(new ItemDef.Pair()
                     {
                         itemDef1 = IronHeart.itemDef,
                         itemDef2 = IronHeartVoid.itemDef
-                    },
+                    });
+                }
+
+                if (HereticSeal.isEnabled && ShadowCrest.isEnabled)
+                {
                     // Seal of the Heretic => Shadow Crest
-                    new ItemDef.Pair()
+                    newVoidPairs.Add(new ItemDef.Pair()
                     {
                         itemDef1 = HereticSeal.itemDef,
                         itemDef2 = ShadowCrest.itemDef
-                    }
-                };
-
+                    });
+                }
+                
                 ItemRelationshipType key = DLC1Content.ItemRelationshipTypes.ContagiousItem;
                 Debug.Log(key);
 


### PR DESCRIPTION
### 0.4.6
- Fixed a bug where DLC-corruptible items were not able to be disabled in the config files.
- Changed
    - **Carving Blade**
        - Damage Cap: ~~200x BASE damage~~ ⇒ 100x BASE damage
    - **Photodiode**
        - Attack Speed: ~~2.5% per stack~~ ⇒ 2% per stack
        - Max Attack Speed: unchanged
    - **Fleece Hoodie**
        - Recharge Time: ~~8 seconds~~ ⇒ 10 seconds
    - **Glass Marbles**
        - Base Damage: ~~2.5 per level~~ ⇒ 2 per level
    - **Defiled Heart**
        - Base Damage: ~~1% max HP~~ ⇒ 1.5% max HP
    - **Shadow Crest**
        - Health Regen: ~~1.5% missing HP~~ ⇒ 1.2% missing HP